### PR TITLE
Exporting the types: SHA1State, SHA256State, SHA512State

### DIFF
--- a/Data/Digest/Pure/SHA.hs
+++ b/Data/Digest/Pure/SHA.hs
@@ -5,6 +5,7 @@
 module Data.Digest.Pure.SHA
        ( -- * 'Digest' and related functions
          Digest
+       , SHA1State, SHA256State, SHA512State
        , showDigest
        , integerDigest
        , bytestringDigest


### PR DESCRIPTION
This allows users to:

hash :: (Serialize a) => a -> Digest SHA1State
hash = sha1 . encodeLazy
