### PR TITLE
Fix Binary instances for digests

### DIFF
--- a/src/Data/Digest/Pure/SHA.hs
+++ b/src/Data/Digest/Pure/SHA.hs
@@ -57,15 +57,15 @@ instance Show (Digest t) where
 
 instance Binary (Digest SHA1State) where
   get = Digest `fmap` getLazyByteString 20
-  put (Digest bs) = put bs
+  put (Digest bs) = putLazyByteString bs
 
 instance Binary (Digest SHA256State) where
   get = Digest `fmap` getLazyByteString 32
-  put (Digest bs) = put bs
+  put (Digest bs) = putLazyByteString bs
 
 instance Binary (Digest SHA512State) where
   get = Digest `fmap` getLazyByteString 64
-  put (Digest bs) = put bs
+  put (Digest bs) = putLazyByteString bs
 
 -- --------------------------------------------------------------------------
 --


### PR DESCRIPTION
Previous code was using `put` instead of `putLazyByteString`, therefore
an additional Int was stored (the length of the bytestring). However, the
getter uses `getLazyByteString` with the expected length of the digest
and does not expect the bytestring length to be present.